### PR TITLE
Add Nightmare Heart's eyes glow (NKG phase 2)

### DIFF
--- a/RemoveLaggyObjects/ModClass.cs
+++ b/RemoveLaggyObjects/ModClass.cs
@@ -50,6 +50,10 @@ namespace RemoveLaggyObjects
             {
                 GameManager.instance.StartCoroutine(RemoveAbyssParticles());
             }
+            else if(arg1.name == "Grimm_Nightmare" || arg1.name == "GG_Grimm_Nightmare")
+            {
+                GameManager.instance.StartCoroutine(RemoveHeartEyesGlow());
+            }
         }
 
         // Meant for use in Sly's fight
@@ -116,5 +120,14 @@ namespace RemoveLaggyObjects
             }
         }
 
+        private IEnumerator RemoveHeartEyesGlow()
+        {
+            yield return new WaitForFinishedEnteringScene();
+            
+            foreach (GameObject go in UnityEngine.Object.FindObjectsOfType<GameObject>())
+            {
+                if (go.name.Contains("Halfway Glow")) UnityEngine.Object.Destroy(go);
+            }
+        }
     }
 }


### PR DESCRIPTION
The glow effect of the Nightmare Heart eyes appearing in phase 2 in the background of NKG causes a significant fps drop, so this removes it. (Also I just noticed I didn't add a comment before the Coroutine, feel free to add it to match the others)